### PR TITLE
feat: Changed Behavior of `MaxLevelOfParallelismAttribute`

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <Title>$(PackageId)</Title>
-    <Description>This library provides various compatibility features between `NUnit` and `XUnit`.</Description>
+    <Description>This library provides various compatibility features between `NUnit`, `XUnit` and `MSTest`.</Description>
 
     <CopyrightYearStart>2023</CopyrightYearStart>
 

--- a/src/NetEvolve.Extensions.NUnit/MaxLevelOfParallelismAttribute.cs
+++ b/src/NetEvolve.Extensions.NUnit/MaxLevelOfParallelismAttribute.cs
@@ -22,13 +22,5 @@ public sealed class MaxLevelOfParallelismAttribute : PropertyAttribute
     /// </summary>
     /// <param name="level">The number of worker threads to be created by the framework.</param>
     public MaxLevelOfParallelismAttribute(int level)
-        : this(level, Environment.ProcessorCount - 1) { }
-
-    /// <summary>
-    /// Construct a <see cref="MaxLevelOfParallelismAttribute"/>.
-    /// </summary>
-    /// <param name="level">The number of worker threads to be created by the framework.</param>
-    /// <param name="alternativeLevel">The number of workers, which should be used alternatively.</param>
-    public MaxLevelOfParallelismAttribute(int level, int alternativeLevel)
-        : base("LevelOfParallelism", Math.Min(level, alternativeLevel)) { }
+        : base("LevelOfParallelism", Math.Min(level, (int)(Environment.ProcessorCount * .75))) { }
 }

--- a/tests/NetEvolve.Extensions.NUnit.Tests.Unit/AssemblyAttributes.cs
+++ b/tests/NetEvolve.Extensions.NUnit.Tests.Unit/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using NetEvolve.Extensions.NUnit;
+
+[assembly: MaxLevelOfParallelism(12)]


### PR DESCRIPTION
Instead of `Environment.ProcessCount - 1` the alternative Value is `(int)(Environment.ProcessorCount * .75)`