### PR TITLE
fix(ci): Publish only on human trigger

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   nuget:
     name: Publish
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
     uses: dailydevops/pipelines/.github/workflows/publish-nuget.yml@1.2.27
     with:
       workflowName: ${{ github.event.workflow_run.name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation to prevent NuGet package publishing when triggered by specific bot accounts, extending existing safeguards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->