### PR TITLE
fix: Updated PublicAPI Definition

### DIFF
--- a/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet10_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet10_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
@@ -114,3 +114,11 @@ namespace NetEvolve.Extensions.TUnit.Internal
         public System.Threading.Tasks.ValueTask OnTestDiscovered(TUnit.Core.DiscoveredTestContext context) { }
     }
 }
+namespace NetEvolve.Extensions.TUnit.Logging
+{
+    public static class TUnitLoggerExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILogger ConvertTo(this TUnit.Core.Logging.ILogger logger) { }
+        public static Microsoft.Extensions.Logging.ILogger<T> ConvertTo<T>(this TUnit.Core.Logging.ILogger logger) { }
+    }
+}

--- a/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet6_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet6_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
@@ -114,3 +114,11 @@ namespace NetEvolve.Extensions.TUnit.Internal
         public System.Threading.Tasks.ValueTask OnTestDiscovered(TUnit.Core.DiscoveredTestContext context) { }
     }
 }
+namespace NetEvolve.Extensions.TUnit.Logging
+{
+    public static class TUnitLoggerExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILogger ConvertTo(this TUnit.Core.Logging.ILogger logger) { }
+        public static Microsoft.Extensions.Logging.ILogger<T> ConvertTo<T>(this TUnit.Core.Logging.ILogger logger) { }
+    }
+}

--- a/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet8_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet8_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
@@ -114,3 +114,11 @@ namespace NetEvolve.Extensions.TUnit.Internal
         public System.Threading.Tasks.ValueTask OnTestDiscovered(TUnit.Core.DiscoveredTestContext context) { }
     }
 }
+namespace NetEvolve.Extensions.TUnit.Logging
+{
+    public static class TUnitLoggerExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILogger ConvertTo(this TUnit.Core.Logging.ILogger logger) { }
+        public static Microsoft.Extensions.Logging.ILogger<T> ConvertTo<T>(this TUnit.Core.Logging.ILogger logger) { }
+    }
+}

--- a/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet9_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/_snapshots/DotNet9_0/PublicApiTests.PublicApi_HasNotChanged_Expected.verified.txt
@@ -114,3 +114,11 @@ namespace NetEvolve.Extensions.TUnit.Internal
         public System.Threading.Tasks.ValueTask OnTestDiscovered(TUnit.Core.DiscoveredTestContext context) { }
     }
 }
+namespace NetEvolve.Extensions.TUnit.Logging
+{
+    public static class TUnitLoggerExtensions
+    {
+        public static Microsoft.Extensions.Logging.ILogger ConvertTo(this TUnit.Core.Logging.ILogger logger) { }
+        public static Microsoft.Extensions.Logging.ILogger<T> ConvertTo<T>(this TUnit.Core.Logging.ILogger logger) { }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extension methods for converting between TUnit and Microsoft.Extensions.Logging interfaces, including support for both standard and generic logger variants. These new conversion utilities are now available across all supported .NET versions: 6.0, 8.0, 9.0, and 10.0, expanding API surface coverage for logging integration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->