### PR TITLE
test: close unit test coverage gaps for NUnit and TUnit

### DIFF
--- a/tests/NetEvolve.Extensions.NUnit.Tests.Unit/ContinuousTestBaseTests.cs
+++ b/tests/NetEvolve.Extensions.NUnit.Tests.Unit/ContinuousTestBaseTests.cs
@@ -1,0 +1,95 @@
+namespace NetEvolve.Extensions.NUnit.Tests.Unit;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using global::NUnit.Framework;
+using global::NUnit.Framework.Interfaces;
+using global::NUnit.Framework.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="ContinuousTestBase"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="ContinuousTestBase"/> relies on the outcome of the previously executed test, which is tracked by NUnit
+/// via <see cref="TestExecutionContext.CurrentContext"/>. To exercise this behavior without spinning up a nested
+/// test run, the tests below temporarily swap the ambient <see cref="TestExecutionContext"/> for an isolated one and
+/// simulate the previous test result directly.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public class ContinuousTestBaseTests
+{
+    /// <summary>
+    /// Tests that the setup does not disable the test execution, if the previous test succeeded.
+    /// </summary>
+    [Test]
+    public async Task SetUpAsync_PreviousTestSucceeded_DoesNotDisableExecution()
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            var context = TestExecutionContext.CurrentContext;
+            SetPreviousResult(context, ResultState.Success);
+
+            var sut = new TestFixture();
+
+            Assert.DoesNotThrowAsync(() => sut.SetUpAsync());
+
+            await sut.TearDownAsync();
+
+            Assert.DoesNotThrowAsync(() => sut.SetUpAsync());
+        }
+    }
+
+    /// <summary>
+    /// Tests that a failing test disables the execution of all subsequent tests within the same fixture instance.
+    /// </summary>
+    [Test]
+    public async Task TearDownAsync_PreviousTestFailed_DisablesSubsequentExecution()
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            var context = TestExecutionContext.CurrentContext;
+            SetPreviousResult(context, ResultState.Failure);
+
+            var sut = new TestFixture();
+
+            Assert.DoesNotThrowAsync(() => sut.SetUpAsync());
+
+            await sut.TearDownAsync();
+
+            _ = Assert.ThrowsAsync<InconclusiveException>(() => sut.SetUpAsync());
+        }
+    }
+
+    /// <summary>
+    /// Tests that the execution stays disabled for every following test, once it has been disabled.
+    /// </summary>
+    [Test]
+    public async Task SetUpAsync_ExecutionAlreadyDisabled_StaysDisabled()
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            var context = TestExecutionContext.CurrentContext;
+            SetPreviousResult(context, ResultState.Failure);
+
+            var sut = new TestFixture();
+
+            await sut.TearDownAsync();
+
+            _ = Assert.ThrowsAsync<InconclusiveException>(() => sut.SetUpAsync());
+
+            SetPreviousResult(context, ResultState.Success);
+            await sut.TearDownAsync();
+
+            _ = Assert.ThrowsAsync<InconclusiveException>(() => sut.SetUpAsync());
+        }
+    }
+
+    private static void SetPreviousResult(TestExecutionContext context, ResultState resultState)
+    {
+        var result = new TestCaseResult((TestMethod)context.CurrentTest);
+        result.SetResult(resultState);
+        context.CurrentResult = result;
+    }
+
+    private sealed class TestFixture : ContinuousTestBase;
+}

--- a/tests/NetEvolve.Extensions.NUnit.Tests.Unit/IssueAttributeTests.cs
+++ b/tests/NetEvolve.Extensions.NUnit.Tests.Unit/IssueAttributeTests.cs
@@ -3,6 +3,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using global::NUnit.Framework;
+using global::NUnit.Framework.Interfaces;
 
 /// <summary>
 /// Unit tests for <see cref="IssueAttribute"/>.
@@ -45,5 +46,16 @@ public class IssueAttributeTests : AttributeTestsBase
         var properties = GetProperties();
 
         _ = await Verify(properties);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="IApplyToTest.ApplyToTest"/> is a no-op when invoked with a <see langword="null"/> test.
+    /// </summary>
+    [Test]
+    public void ApplyToTest_TestIsNull_DoesNotThrow()
+    {
+        var attribute = new IssueAttribute("123456");
+
+        Assert.DoesNotThrow(() => ((IApplyToTest)attribute).ApplyToTest(null!));
     }
 }

--- a/tests/NetEvolve.Extensions.NUnit.Tests.Unit/TestGroupAttributeTests.cs
+++ b/tests/NetEvolve.Extensions.NUnit.Tests.Unit/TestGroupAttributeTests.cs
@@ -1,0 +1,52 @@
+namespace NetEvolve.Extensions.NUnit.Tests.Unit;
+
+using System.Diagnostics.CodeAnalysis;
+using global::NUnit.Framework;
+using global::NUnit.Framework.Interfaces;
+using global::NUnit.Framework.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="TestGroupAttribute"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class TestGroupAttributeTests
+{
+    /// <summary>
+    /// Tests that <see cref="TestGroupAttribute"/> adds the group name as a test property.
+    /// </summary>
+    [Test]
+    public void ApplyToTest_WithId_AddsProperty()
+    {
+        var attribute = new TestGroupAttribute("MyGroup");
+        var test = new TestSuite(nameof(TestGroupAttributeTests));
+
+        attribute.ApplyToTest(test);
+
+        Assert.That(test.Properties[attribute.Category], Does.Contain("MyGroup"));
+    }
+
+    /// <summary>
+    /// Tests that <see cref="TestGroupAttribute"/> does not add a property, when the id is empty.
+    /// </summary>
+    [Test]
+    public void ApplyToTest_WithEmptyId_DoesNotAddProperty()
+    {
+        var attribute = new TestGroupAttribute(string.Empty);
+        var test = new TestSuite(nameof(TestGroupAttributeTests));
+
+        attribute.ApplyToTest(test);
+
+        Assert.That(test.Properties[attribute.Category], Is.Empty);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="IApplyToTest.ApplyToTest"/> is a no-op when invoked with a <see langword="null"/> test.
+    /// </summary>
+    [Test]
+    public void ApplyToTest_TestIsNull_DoesNotThrow()
+    {
+        var attribute = new TestGroupAttribute("MyGroup");
+
+        Assert.DoesNotThrow(() => ((IApplyToTest)attribute).ApplyToTest(null!));
+    }
+}

--- a/tests/NetEvolve.Extensions.TUnit.Tests.Unit/AcceptanceTestAttributeTests.cs
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.Unit/AcceptanceTestAttributeTests.cs
@@ -23,4 +23,15 @@ public class AcceptanceTestAttributeTests : AttributeTestsBase
 
     [AcceptanceTest]
     protected void AcceptanceTest_without_parameters() => throw new NotSupportedException();
+
+    /// <summary>
+    /// Tests that <see cref="Internal.CategoryTraitBaseAttribute.OnTestDiscovered"/> is a no-op, when invoked with a <see langword="null"/> context.
+    /// </summary>
+    [Test]
+    public async Task OnTestDiscovered_ContextIsNull_DoesNotThrow()
+    {
+        var attribute = new AcceptanceTestAttribute();
+
+        await attribute.OnTestDiscovered(null!).ConfigureAwait(false);
+    }
 }

--- a/tests/NetEvolve.Extensions.TUnit.Tests.Unit/BugAttributeTests.cs
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.Unit/BugAttributeTests.cs
@@ -45,4 +45,15 @@ public class BugAttributeTests : AttributeTestsBase
 
         _ = await Verify(traits).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Tests that <see cref="Internal.CategoryWithIdTraitBaseAttribute.OnTestDiscovered"/> is a no-op, when invoked with a <see langword="null"/> context.
+    /// </summary>
+    [Test]
+    public async Task OnTestDiscovered_ContextIsNull_DoesNotThrow()
+    {
+        var attribute = new BugAttribute();
+
+        await attribute.OnTestDiscovered(null!).ConfigureAwait(false);
+    }
 }

--- a/tests/NetEvolve.Extensions.TUnit.Tests.Unit/Logging/TUnitLoggerTests.cs
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.Unit/Logging/TUnitLoggerTests.cs
@@ -1,0 +1,107 @@
+﻿namespace NetEvolve.Extensions.TUnit.Tests.Unit.Logging;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using global::Microsoft.Extensions.Logging;
+using NetEvolve.Extensions.TUnit.Logging;
+using TUnitLogLevel = global::TUnit.Core.Logging.LogLevel;
+
+/// <summary>
+/// Unit tests for <see cref="TUnitLogger"/>, <see cref="TUnitLogger{T}"/> and <see cref="TUnitLoggerExtensions"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class TUnitLoggerTests
+{
+    [Test]
+    [Arguments(LogLevel.Trace, TUnitLogLevel.Trace)]
+    [Arguments(LogLevel.Debug, TUnitLogLevel.Debug)]
+    [Arguments(LogLevel.Information, TUnitLogLevel.Information)]
+    [Arguments(LogLevel.Warning, TUnitLogLevel.Warning)]
+    [Arguments(LogLevel.Error, TUnitLogLevel.Error)]
+    [Arguments(LogLevel.Critical, TUnitLogLevel.Critical)]
+    [Arguments(LogLevel.None, TUnitLogLevel.None)]
+    public async Task IsEnabled_ConvertsLogLevel_UsesUnderlyingLogger(LogLevel logLevel, TUnitLogLevel expected)
+    {
+        var innerLogger = new FakeTUnitLogger(expected, isEnabled: true);
+        var logger = innerLogger.ConvertTo();
+
+        var result = logger.IsEnabled(logLevel);
+
+        _ = await Assert.That(result).IsTrue();
+        _ = await Assert.That(innerLogger.LastIsEnabledLevel).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Log_DelegatesToUnderlyingLogger_WithConvertedLevelAndFormattedMessage()
+    {
+        var innerLogger = new FakeTUnitLogger(TUnitLogLevel.Information, isEnabled: true);
+        var logger = innerLogger.ConvertTo();
+        var exception = new InvalidOperationException("boom");
+
+        logger.Log(LogLevel.Information, new EventId(1), "state", exception, (state, ex) => $"{state}-{ex?.Message}");
+
+        _ = await Assert.That(innerLogger.LastLogLevel).IsEqualTo(TUnitLogLevel.Information);
+        _ = await Assert.That(innerLogger.LastMessage).IsEqualTo("state-boom");
+    }
+
+    [Test]
+    public async Task BeginScope_ReturnsSharedNullScopeInstance()
+    {
+        var logger = new FakeTUnitLogger(TUnitLogLevel.Information, isEnabled: true).ConvertTo();
+
+        using var scopeA = logger.BeginScope("scope-a");
+        using var scopeB = logger.BeginScope("scope-b");
+
+        _ = await Assert.That(scopeA).IsSameReferenceAs(scopeB);
+
+        scopeA?.Dispose();
+    }
+
+    [Test]
+    public async Task ConvertTo_Generic_CreatesTypedLogger()
+    {
+        var logger = new FakeTUnitLogger(TUnitLogLevel.Information, isEnabled: true).ConvertTo<TUnitLoggerTests>();
+
+        _ = await Assert.That(logger).IsNotNull();
+        _ = await Assert.That(logger.IsEnabled(LogLevel.Information)).IsTrue();
+    }
+
+    private sealed class FakeTUnitLogger(TUnitLogLevel enabledLevel, bool isEnabled)
+        : global::TUnit.Core.Logging.ILogger
+    {
+        public TUnitLogLevel? LastIsEnabledLevel { get; private set; }
+
+        public TUnitLogLevel? LastLogLevel { get; private set; }
+
+        public string? LastMessage { get; private set; }
+
+        public bool IsEnabled(TUnitLogLevel logLevel)
+        {
+            LastIsEnabledLevel = logLevel;
+            return isEnabled && logLevel == enabledLevel;
+        }
+
+        public void Log<TState>(
+            TUnitLogLevel logLevel,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            LastLogLevel = logLevel;
+            LastMessage = formatter(state, exception);
+        }
+
+        public ValueTask LogAsync<TState>(
+            TUnitLogLevel logLevel,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            Log(logLevel, state, exception, formatter);
+            return new ValueTask();
+        }
+    }
+}

--- a/tests/NetEvolve.Extensions.TUnit.Tests.Unit/SkipOnFailureAttributeTests.cs
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.Unit/SkipOnFailureAttributeTests.cs
@@ -11,4 +11,22 @@ public class SkipOnFailureAttributeTests
         var alwaysFalse = 1 + 1 == 3;
         _ = await Assert.That(alwaysFalse).IsTrue();
     }
+
+    [Test]
+    [SkipOnFailure]
+    public async Task Test_Succeeds_StaysSucceeded()
+    {
+        // This test always succeeds, to demonstrate that SkipOnFailureAttribute
+        // does not affect the outcome of a passing test.
+        var alwaysTrue = 1 + 1 == 2;
+        _ = await Assert.That(alwaysTrue).IsTrue();
+    }
+
+    [Test]
+    public async Task OnTestEnd_ContextIsNull_DoesNotThrow()
+    {
+        var attribute = new SkipOnFailureAttribute();
+
+        await attribute.OnTestEnd(null!).ConfigureAwait(false);
+    }
 }

--- a/tests/NetEvolve.Extensions.TUnit.Tests.Unit/TestGroupAttributeTests.cs
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.Unit/TestGroupAttributeTests.cs
@@ -1,0 +1,27 @@
+﻿namespace NetEvolve.Extensions.TUnit.Tests.Unit;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Unit tests for <see cref="TestGroupAttribute"/>.
+/// </summary>
+/// <remarks>
+/// The "TestGroup" trait itself is already exercised assembly-wide, via the <c>[TestGroup("TUnit")]</c> assembly
+/// attribute declared in the project file; these tests only cover the defensive branch of
+/// <see cref="Internal.NamedCategoryTraitBaseAttribute.OnTestDiscovered"/>.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public class TestGroupAttributeTests
+{
+    /// <summary>
+    /// Tests that <see cref="Internal.NamedCategoryTraitBaseAttribute.OnTestDiscovered"/> is a no-op, when invoked with a <see langword="null"/> context.
+    /// </summary>
+    [Test]
+    public async Task OnTestDiscovered_ContextIsNull_DoesNotThrow()
+    {
+        var attribute = new TestGroupAttribute("MyGroup");
+
+        await attribute.OnTestDiscovered(null!).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary

Closes unit test coverage gaps for the NUnit and TUnit extension libraries, uncovered by measuring actual coverage directly (bypassing `dotnet test`, see note below).

| Framework | Before | After |
|---|---|---|
| MSTest | 100 % | 100 % (no change needed) |
| NUnit | 85.1 % | **100 %** |
| TUnit | 73 % | **98.8 %** |
| XUnit.V3 | 100 % | 100 % (no change needed) |

All 616 tests pass (up from 535), no snapshot changes.

## What was added

**NUnit**
- `IssueAttributeTests`: cover the defensive null-test branch of `CategoryIdBaseAttribute.ApplyToTest`.
- `TestGroupAttributeTests` (new): cover `NamedCategoryBaseAttribute.ApplyToTest`, including the empty-id and null-test branches. This attribute had no dedicated tests before.
- `ContinuousTestBaseTests` (new): covers the order-dependent skip logic (a failing test disables all subsequent tests in the fixture), which was previously untested (0 %). No nested test run is needed — the ambient `TestExecutionContext` is temporarily swapped for an isolated one, and a simulated previous test result is set directly, keeping this a genuine unit test rather than requiring an integration test project.

**TUnit**
- `AcceptanceTestAttributeTests` / `BugAttributeTests`: cover the defensive null-context branch of `CategoryTraitBaseAttribute.OnTestDiscovered` / `CategoryWithIdTraitBaseAttribute.OnTestDiscovered`.
- `TestGroupAttributeTests` (new): covers `NamedCategoryTraitBaseAttribute.OnTestDiscovered`'s null-context branch. This attribute had no dedicated tests before.
- `SkipOnFailureAttributeTests`: adds a passing-test case and a null-context case.
- `Logging/TUnitLoggerTests` (new): first tests for `TUnitLogger`, `TUnitLogger<T>`, `TUnitLoggerExtensions` and `TUnitNullScope` — previously 0 % covered.

One branch is deliberately left uncovered: `SkipOnFailureAttribute.OnTestEnd`'s `context.Execution.Result == null` case (87.5 % line / 83.3 % branch) is only reachable through TUnit-internal state that isn't practically constructible from a test.

## Note on measurement

Coverage numbers above were measured by invoking the built test assemblies directly (`dotnet <dll> --coverage --coverage-output-format cobertura`), not via `dotnet test`. Under `dotnet test`, `Microsoft.Testing.Extensions.CodeCoverage` currently reports empty coverage (`<packages/>`) for the MSTest and TUnit test hosts specifically — reproducible in isolation, root cause traced to the coverage extension's `TestingPlatformCoverageDynamicTestSessionLifetimeHandler` never activating in the worker process spawned by `dotnet test`'s `--server dotnettestcli` mode for these two runners (NUnit and XUnit.V3 are unaffected). This is a separate, pre-existing pipeline issue in `dailydevops/pipelines` (`step-dotnet-tests.yml`), tracked separately — not something this PR attempts to fix, since it lives outside this repository.
