### PR TITLE
fix(tests): prevent SymbolsNotMatchingException in PublicApi tests

### DIFF
--- a/tests/NetEvolve.Extensions.MSTest.Tests.PublicApi/NetEvolve.Extensions.MSTest.Tests.PublicApi.csproj
+++ b/tests/NetEvolve.Extensions.MSTest.Tests.PublicApi/NetEvolve.Extensions.MSTest.Tests.PublicApi.csproj
@@ -7,6 +7,11 @@
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
 
     <OutputType>Exe</OutputType>
+    <!-- Do not copy referenced .pdb files to the output directory. PublicApiGenerator reads the
+         assembly under test via Mono.Cecil, which throws SymbolsNotMatchingException if it finds
+         a .pdb next to the assembly that code coverage instrumentation has rewritten out of sync
+         with it. The public API surface does not require debug symbols. -->
+    <AllowedReferenceRelatedFileExtensions>.xml</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />

--- a/tests/NetEvolve.Extensions.NUnit.Tests.PublicApi/NetEvolve.Extensions.NUnit.Tests.PublicApi.csproj
+++ b/tests/NetEvolve.Extensions.NUnit.Tests.PublicApi/NetEvolve.Extensions.NUnit.Tests.PublicApi.csproj
@@ -5,6 +5,11 @@
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!-- Do not copy referenced .pdb files to the output directory. PublicApiGenerator reads the
+         assembly under test via Mono.Cecil, which throws SymbolsNotMatchingException if it finds
+         a .pdb next to the assembly that code coverage instrumentation has rewritten out of sync
+         with it. The public API surface does not require debug symbols. -->
+    <AllowedReferenceRelatedFileExtensions>.xml</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />

--- a/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/NetEvolve.Extensions.TUnit.Tests.PublicApi.csproj
+++ b/tests/NetEvolve.Extensions.TUnit.Tests.PublicApi/NetEvolve.Extensions.TUnit.Tests.PublicApi.csproj
@@ -3,6 +3,11 @@
     <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <!-- Do not copy referenced .pdb files to the output directory. PublicApiGenerator reads the
+         assembly under test via Mono.Cecil, which throws SymbolsNotMatchingException if it finds
+         a .pdb next to the assembly that code coverage instrumentation has rewritten out of sync
+         with it. The public API surface does not require debug symbols. -->
+    <AllowedReferenceRelatedFileExtensions>.xml</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />

--- a/tests/NetEvolve.Extensions.XUnit.V3.Tests.PublicApi/NetEvolve.Extensions.XUnit.V3.Tests.PublicApi.csproj
+++ b/tests/NetEvolve.Extensions.XUnit.V3.Tests.PublicApi/NetEvolve.Extensions.XUnit.V3.Tests.PublicApi.csproj
@@ -3,6 +3,11 @@
     <TargetFrameworks>$(NetEvolve_TestTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
+    <!-- Do not copy referenced .pdb files to the output directory. PublicApiGenerator reads the
+         assembly under test via Mono.Cecil, which throws SymbolsNotMatchingException if it finds
+         a .pdb next to the assembly that code coverage instrumentation has rewritten out of sync
+         with it. The public API surface does not require debug symbols. -->
+    <AllowedReferenceRelatedFileExtensions>.xml</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" VersionOverride="18.0.6" />


### PR DESCRIPTION
## Problem

`PublicApi_HasNotChanged_Expected` intermittently fails on CI across the NUnit, MSTest, TUnit and XUnit.V3 PublicApi test projects with:

```
Mono.Cecil.Cil.SymbolsNotMatchingException: Symbols were found but are not matching the assembly
```

This is cross-project and cross-TFM (observed on net6.0, net8.0 and net9.0, in NUnit's, MSTest's and TUnit's PublicApi projects on different runs), and predates the recent TUnit package bump (#1353), so it isn't caused by a single dependency.

PublicApiGenerator reads the assembly under test (a `ProjectReference` to the corresponding `src` project) via Mono.Cecil, which throws when it finds a `.pdb` next to the assembly that doesn't match it byte-for-byte. All four affected projects reference `Microsoft.Testing.Extensions.CodeCoverage`, which instruments assemblies for coverage collection at test time — the leading explanation is a race between that instrumentation and Mono.Cecil reading the `.pdb`.

## Fix

The public API surface does not require debug symbols. Set `AllowedReferenceRelatedFileExtensions` to `.xml` in each PublicApi test project so the referenced project's `.pdb` is no longer copied into the test output directory — removing the file Mono.Cecil could find mismatched, rather than trying to win the race against the coverage instrumentation.

Verified locally (net10.0) that the `.pdb` is no longer copied and that `PublicApi_HasNotChanged_Expected` still passes, with and without `--coverage`, in all four PublicApi projects.
